### PR TITLE
Handle missing comment on edit

### DIFF
--- a/routes/comments.js
+++ b/routes/comments.js
@@ -55,11 +55,11 @@ router.get("/:comment_id/edit", middleware.checkCommentOwnership, function(req, 
             return res.redirect("back");
         }
         Comment.findById(req.params.comment_id, function(err, foundComment){
-            if(err){
-                res.redirect("back");
-            } else{
-                res.render("comments/edit", {campground_id: req.params.id, comment: foundComment});
+            if(err || !foundComment){
+                req.flash("error", "Comment not found");
+                return res.redirect("back");
             }
+            res.render("comments/edit", {campground_id: req.params.id, comment: foundComment});
         });
     }); 
 });


### PR DESCRIPTION
## Summary
- ensure comment edit route gracefully handles missing comments by flashing an error and redirecting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cd2013288331b67b7c7c5b1db112